### PR TITLE
Adds a bio field in the users profile

### DIFF
--- a/src/repositories/sql/users/_table.sql
+++ b/src/repositories/sql/users/_table.sql
@@ -8,6 +8,7 @@ CREATE TABLE users (
     "contact" TEXT DEFAULT NULL,
     "avatar_image" TEXT DEFAULT '/assets/noavatar.jpg',
     "background_image" TEXT DEFAULT '/assets/nobg.jpg',
+    "bio" TEXT DEFAULT NULL,
     "show_name" BOOLEAN DEFAULT FALSE,
     "show_email" BOOLEAN DEFAULT FALSE,
     "show_contact" BOOLEAN DEFAULT FALSE,


### PR DESCRIPTION
Closes #59 

For this situation, I've just updated the user profile field and added the bio. 

Also, for the screenshots. I have made a new different instance for this and here is how a user looked like.


![user](https://user-images.githubusercontent.com/61931218/139581990-52bcc224-4412-4539-8169-8c74fb921cbe.PNG)


Also, for this to work, it is important that the usertype_id and the permission id is the same in order for this to work. Since according to the code before, we have set "1" as the default value for the usertype.


Create table code:


![create table](https://user-images.githubusercontent.com/61931218/139582057-18eec2d7-c3b0-46a5-815a-fed6e375f13b.PNG)


Usertypes:


![usertypes](https://user-images.githubusercontent.com/61931218/139582071-39a62c54-7a51-4933-b8a6-3b23751eac28.PNG)

 