### PR TITLE
Fix post likes counter 

### DIFF
--- a/src/repositories/sql/create.sql
+++ b/src/repositories/sql/create.sql
@@ -167,12 +167,11 @@ CREATE OR REPLACE RULE check_userpost AS
 
 CREATE OR REPLACE RULE count_likes AS
 	ON UPDATE TO userpost
-	DO ALSO
-		UPDATE posts SET likes_count = 
-			(SELECT COUNT(*)
-			FILTER (WHERE userpost.is_liked AND posts.post_id=userpost.post_id)
-			FROM userpost)
-		WHERE new.post_id = posts.post_id;
+	DO ALSO UPDATE posts SET likes_count = 
+			(SELECT COUNT (*)
+			FROM userpost
+			WHERE is_liked AND userpost.post_id = new.post_id) + 1
+	WHERE posts.post_id = new.post_id;
 
 -- count view
 


### PR DESCRIPTION
Closes #125 

Issue: I remembered as to why I needed the + 1 before. I think it was because this starts at 0?

Also the unlike feature (based from the discussion yesterday): I will just place a limitation in Chapter 1 that we can't unlike.

But in this scenario (screenshots) I have addressed the issue.

Note: I also checked with the fetch_profile.sql. The code still works as intended despite the change.

