### PR TITLE
Dashboard SQL - Report Entries (Users) - reopened

### DIFF
--- a/src/repositories/sql/_dashboard/reported_users.sql
+++ b/src/repositories/sql/_dashboard/reported_users.sql
@@ -1,0 +1,37 @@
+DROP VIEW IF EXISTS reported_users;
+
+CREATE VIEW reported_users AS
+    SELECT 
+        reports.report_id,
+        reports.target_user_id,
+        (SELECT username FROM users WHERE users.user_id = reports.target_user_id) AS target_username,
+        reports.user_id,
+        (SELECT username FROM users WHERE users.user_id = reports.user_id) AS complainee_username,
+        reports.offense_id,
+        (SELECT offense_title FROM offenses WHERE offenses.offense_id = reports.offense_id) AS offense_title,
+        (SELECT ban_time FROM offenses WHERE offenses.offense_id = reports.offense_id),
+        reports.report_note,
+        reports.created_at
+    FROM reports
+    ORDER BY reports.created_at ASC;
+
+SELECT * FROM reported_users;
+
+-- DROP VIEW IF EXISTS pending_posts;
+
+-- CREATE VIEW pending_posts AS
+--     SELECT 
+--         posts.post_id,
+--         posts.user_id,
+--         users.username,
+--         posts.post_title,
+--         posts.post_body,
+--         posts.post_image,
+--         posts.post_video,
+--         posts.created_at
+--     FROM posts
+--     INNER JOIN users ON users.user_id = posts.user_id
+--     WHERE posts.status_id = 'ps1'
+--     ORDER BY 
+--         created_at DESC;
+-- SELECT * FROM pending_posts;

--- a/src/repositories/sql/_dashboard/reported_users.sql
+++ b/src/repositories/sql/_dashboard/reported_users.sql
@@ -16,22 +16,3 @@ CREATE VIEW reported_users AS
     ORDER BY reports.created_at ASC;
 
 SELECT * FROM reported_users;
-
--- DROP VIEW IF EXISTS pending_posts;
-
--- CREATE VIEW pending_posts AS
---     SELECT 
---         posts.post_id,
---         posts.user_id,
---         users.username,
---         posts.post_title,
---         posts.post_body,
---         posts.post_image,
---         posts.post_video,
---         posts.created_at
---     FROM posts
---     INNER JOIN users ON users.user_id = posts.user_id
---     WHERE posts.status_id = 'ps1'
---     ORDER BY 
---         created_at DESC;
--- SELECT * FROM pending_posts;

--- a/src/repositories/sql/_dashboard/reported_users.sql
+++ b/src/repositories/sql/_dashboard/reported_users.sql
@@ -14,6 +14,7 @@ CREATE VIEW reported_users AS
         reports.created_at
     FROM reports
     JOIN offenses ON offenses.offense_id = reports.offense_id
+    WHERE offenses.offense_type = 'u'
     ORDER BY reports.created_at ASC;
 
 SELECT * FROM reported_users;

--- a/src/repositories/sql/_dashboard/reported_users.sql
+++ b/src/repositories/sql/_dashboard/reported_users.sql
@@ -8,11 +8,12 @@ CREATE VIEW reported_users AS
         reports.user_id,
         (SELECT username FROM users WHERE users.user_id = reports.user_id) AS complainee_username,
         reports.offense_id,
-        (SELECT offense_title FROM offenses WHERE offenses.offense_id = reports.offense_id) AS offense_title,
-        (SELECT ban_time FROM offenses WHERE offenses.offense_id = reports.offense_id),
+        offenses.offense_title,
+        offenses.ban_time,
         reports.report_note,
         reports.created_at
     FROM reports
+    JOIN offenses ON offenses.offense_id = reports.offense_id
     ORDER BY reports.created_at ASC;
 
 SELECT * FROM reported_users;

--- a/src/repositories/sql/create.sql
+++ b/src/repositories/sql/create.sql
@@ -218,9 +218,10 @@ CREATE VIEW reported_users AS
         reports.user_id,
         (SELECT username FROM users WHERE users.user_id = reports.user_id) AS complainee_username,
         reports.offense_id,
-        (SELECT offense_title FROM offenses WHERE offenses.offense_id = reports.offense_id) AS offense_title,
-        (SELECT ban_time FROM offenses WHERE offenses.offense_id = reports.offense_id),
+        offenses.offense_title,
+        offenses.ban_time,
         reports.report_note,
         reports.created_at
     FROM reports
+    JOIN offenses ON offenses.offense_id = reports.offense_id
     ORDER BY reports.created_at ASC;

--- a/src/repositories/sql/create.sql
+++ b/src/repositories/sql/create.sql
@@ -208,3 +208,19 @@ CREATE VIEW general_overview AS
         (SELECT COUNT (post_id) FROM posts WHERE posts.status_id = 'ps4') AS disabled_posts,
         (SELECT COUNT (comment_id) FROM comments WHERE is_disabled = TRUE) AS disabled_comments,
         (SELECT now()) AS issued_at;
+
+-- reported_users
+CREATE VIEW reported_users AS
+    SELECT 
+        reports.report_id,
+        reports.target_user_id,
+        (SELECT username FROM users WHERE users.user_id = reports.target_user_id) AS target_username,
+        reports.user_id,
+        (SELECT username FROM users WHERE users.user_id = reports.user_id) AS complainee_username,
+        reports.offense_id,
+        (SELECT offense_title FROM offenses WHERE offenses.offense_id = reports.offense_id) AS offense_title,
+        (SELECT ban_time FROM offenses WHERE offenses.offense_id = reports.offense_id),
+        reports.report_note,
+        reports.created_at
+    FROM reports
+    ORDER BY reports.created_at ASC;

--- a/src/repositories/sql/create.sql
+++ b/src/repositories/sql/create.sql
@@ -197,7 +197,7 @@ CREATE OR REPLACE RULE count_comments AS
 		WHERE new.post_id = posts.post_id;
 
 -- Create View
-
+-- general_overview
 CREATE VIEW general_overview AS
     SELECT 
         (SELECT COUNT (DISTINCT target_user_id) FROM reports) AS reported_users,

--- a/src/repositories/sql/create.sql
+++ b/src/repositories/sql/create.sql
@@ -1,5 +1,4 @@
 -- Session
-
 CREATE TABLE "session" (
   "sid" varchar NOT NULL COLLATE "default",
 	"sess" json NOT NULL,
@@ -208,3 +207,21 @@ CREATE VIEW general_overview AS
         (SELECT COUNT (post_id) FROM posts WHERE posts.status_id = 'ps4') AS disabled_posts,
         (SELECT COUNT (comment_id) FROM comments WHERE is_disabled = TRUE) AS disabled_comments,
         (SELECT now()) AS issued_at;
+
+-- reported_users
+
+CREATE VIEW reported_users AS
+    SELECT 
+        reports.report_id,
+        reports.target_user_id,
+        (SELECT username FROM users WHERE users.user_id = reports.target_user_id) AS target_username,
+        reports.user_id,
+        (SELECT username FROM users WHERE users.user_id = reports.user_id) AS complainee_username,
+        reports.offense_id,
+        offenses.offense_title,
+        offenses.ban_time,
+        reports.report_note,
+        reports.created_at
+    FROM reports
+    JOIN offenses ON offenses.offense_id = reports.offense_id
+    ORDER BY reports.created_at ASC;

--- a/src/repositories/sql/create.sql
+++ b/src/repositories/sql/create.sql
@@ -224,4 +224,5 @@ CREATE VIEW reported_users AS
         reports.created_at
     FROM reports
     JOIN offenses ON offenses.offense_id = reports.offense_id
+    WHERE offenses.offense_type = 'u'
     ORDER BY reports.created_at ASC;

--- a/src/repositories/sql/create.sql
+++ b/src/repositories/sql/create.sql
@@ -223,4 +223,5 @@ CREATE VIEW reported_users AS
         reports.created_at
     FROM reports
     JOIN offenses ON offenses.offense_id = reports.offense_id
+    WHERE offenses.offense_type = 'u'
     ORDER BY reports.created_at ASC;

--- a/src/repositories/sql/drop.sql
+++ b/src/repositories/sql/drop.sql
@@ -1,4 +1,7 @@
 -- View
+-- reported_users
+DROP VIEW IF EXISTS reported_users;
+-- general_overview
 DROP VIEW IF EXISTS general_overview;
 -- Rules
 -- add like

--- a/src/repositories/sql/drop.sql
+++ b/src/repositories/sql/drop.sql
@@ -3,6 +3,8 @@
 DROP VIEW IF EXISTS general_overview;
 -- pending_posts
 DROP VIEW IF EXISTS pending_posts;
+-- reported_users
+DROP VIEW IF EXISTS reported_users;
 -- Rules
 -- add like
 DROP RULE IF EXISTS count_likes ON userpost;


### PR DESCRIPTION
I just added a new parameter in this branch.

Closes: #133

`WHERE offenses.offense_type = 'u'`


As seen in the image below, there are 3 reports. 1 post report and 2 user reports.
![image](https://user-images.githubusercontent.com/61931218/152354667-28f98b76-2d14-4437-8b96-b3865df67e06.png)


After reupdating and adding the new param, only 2 reports were shown. 
![image](https://user-images.githubusercontent.com/61931218/152354959-4d4df50f-026a-433c-b0f3-4ae33587cb96.png)
